### PR TITLE
Upgrades to http 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [workspace.dependencies]
 bytes = "1.5"
-http = "0.2"
+http = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 time = { version = "0.3", features = ["formatting", "macros", "parsing", "serde"] }

--- a/trakt-rs/Cargo.toml
+++ b/trakt-rs/Cargo.toml
@@ -28,4 +28,4 @@ unicode-segmentation = "1"
 
 [dev-dependencies]
 httpmock = "0.7"
-reqwest = { version = "0.11", default-features = false, features = ["blocking"] }
+ureq = { version = "2.9", default-features = false, features = ["http-crate"] }

--- a/trakt-rs/src/test.rs
+++ b/trakt-rs/src/test.rs
@@ -1,13 +1,7 @@
-use std::sync::OnceLock;
-
-use bytes::Bytes;
-use reqwest::blocking::Client;
 use trakt_core::{
     error::{FromHttpError, IntoHttpError},
     Context, Request, Response,
 };
-
-static CLIENT: OnceLock<Client> = OnceLock::new();
 
 pub fn assert_request<R, T>(ctx: Context, req: R, exp_url: &str, exp_body: &T)
 where
@@ -41,43 +35,26 @@ where
 }
 
 pub fn execute<R: Request>(ctx: Context, req: R) -> Result<R::Response, Error> {
-    let client = CLIENT.get_or_init(Client::new);
-
     let request: http::Request<Vec<u8>> = req.try_into_http_request(ctx)?;
+    let (parts, body) = request.into_parts();
+    let request = ureq::Request::from(parts);
 
-    let reqwest_res = client.execute(request.try_into()?)?;
-    let http_res = reqwest_to_http(reqwest_res)?;
+    let response = request.send_bytes(&body)?;
+    let http_res: http::Response<Vec<u8>> = http::Response::from(response);
 
     Ok(Response::try_from_http_response(http_res)?)
 }
 
-fn reqwest_to_http(
-    mut response: reqwest::blocking::Response,
-) -> Result<http::Response<Bytes>, Error> {
-    let mut builder = http::Response::builder()
-        .status(response.status())
-        .version(response.version());
-
-    std::mem::swap(
-        builder.headers_mut().expect("response should be valid"),
-        response.headers_mut(),
-    );
-
-    Ok(builder
-        .body(response.bytes()?)
-        .expect("response should be valid"))
-}
-
 #[derive(Debug)]
 pub enum Error {
-    Reqwest(reqwest::Error),
+    Reqwest(Box<ureq::Error>),
     IntoHttp(IntoHttpError),
     FromHttp(FromHttpError),
 }
 
-impl From<reqwest::Error> for Error {
-    fn from(e: reqwest::Error) -> Self {
-        Self::Reqwest(e)
+impl From<ureq::Error> for Error {
+    fn from(e: ureq::Error) -> Self {
+        Self::Reqwest(Box::new(e))
     }
 }
 


### PR DESCRIPTION
- **Update http requirement from 0.2 to 1.1**
- **test: switches from `reqwest` to `ureq` for tests**

Will probably switch back to `reqwest` for tests when [0.12 is released](https://github.com/seanmonstar/reqwest/milestone/6).

Fixes #50.
